### PR TITLE
Octave support

### DIFF
--- a/SDPT3solve.m
+++ b/SDPT3solve.m
@@ -24,4 +24,4 @@ end
 %     disp(num2str(Z{i},12));
 % end
 
-quit;
+end

--- a/result.py
+++ b/result.py
@@ -191,7 +191,7 @@ def extract_X(msg):
 
             # Plug the row's data into the matrix
             for row, line in enumerate(Xmsg_lines):
-                for k, item in enumerate(re.split(r'\s+', line)):
+                for k, item in enumerate(re.split(r'\s+', line.strip())):
                     Xlist[i][row, k] = float(item)
             print "Imported X[{0}] as a matrix with shape {1}.".format(i, Xlist[i].shape)
 

--- a/solve.py
+++ b/solve.py
@@ -26,7 +26,7 @@ def check_output_target(mode, output_target):
             "Something already exists at output_target, we won't overwrite it."
 
 
-def sdpt3_solve_problem(problem, mode, matfile_target, output_target=None, discard_matfile=True):
+def sdpt3_solve_problem(problem, mode, matfile_target, output_target=None, discard_matfile=True, **kwargs):
     '''
     A wrapper function that takes a cvxpy problem, makes the .mat file, solves
     it by NEOS or a local Matlab/SDPT3 installation, then constructs the result,
@@ -43,10 +43,11 @@ def sdpt3_solve_problem(problem, mode, matfile_target, output_target=None, disca
     return sdpt3_solve_mat(matfile_target,
                            mode,
                            output_target=output_target,
-                           discard_matfile=discard_matfile)
+                           discard_matfile=discard_matfile,
+                           **kwargs)
 
 
-def sdpt3_solve_mat(matfile_path, mode, output_target=None, discard_matfile=True):
+def sdpt3_solve_mat(matfile_path, mode, output_target=None, discard_matfile=True, **kwargs):
     '''
     A wrapper function that takes the path of a .mat file, solves the Sedumi
     problem it contains with NEOS or a local Matlab/SDPT3 installation, then
@@ -64,7 +65,8 @@ def sdpt3_solve_mat(matfile_path, mode, output_target=None, discard_matfile=True
     elif mode == 'octave':
         msg = ls.octave_solve(matfile_path,
                               output_target,
-                              discard_matfile=discard_matfile)
+                              discard_matfile=discard_matfile,
+                              **kwargs)
     elif mode == 'neos':
         import solve_neos as ns
         msg = ns.neos_solve(matfile_path,

--- a/solve_locally.py
+++ b/solve_locally.py
@@ -65,6 +65,7 @@ def octave_solve(matfile_target, output_target, discard_matfile=True, cmd="octav
       matfile_target: the path to the .mat file containing the Sedumi format problem data.
       output_target: the path we will save the output log message to.
       discard_matfile: if True, deletes the .mat file after the solve finishes.
+      cmd: command name for octave, which will be used for alternative command.
     Output:
         A dictionary with solve result information.
     '''

--- a/tests/unittest_octave.py
+++ b/tests/unittest_octave.py
@@ -1,0 +1,158 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# pylint: disable=E1101
+"""
+Created on Sun Apr  3 14:56:40 2016
+
+@author: trish
+"""
+
+import unittest
+import os
+import os.path
+import shutil
+
+import numpy as np
+
+import cvxpy
+
+import solve as slv
+import sedumi_writer as sw
+import result as res
+
+OCTAVE_CMD = (
+    "docker run --rm -it -v {workdir}:/data "
+    "jkawamoto/octave-sdpt3 octave"
+).format(workdir=os.path.abspath("."))
+
+
+class TestSimpleOctaveSolve(unittest.TestCase):
+    '''
+    Testing simplification of Sedumi problems.
+    '''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_folder = os.path.abspath("./temp")
+        if not os.path.exists(cls.temp_folder):
+            os.makedirs(cls.temp_folder)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.temp_folder)
+
+    def test_hamming(self):
+        '''
+        Try submitting the .mat for a problem from DIMACS (hamming_7_5_6), to
+        test if we can do submission and result extraction in a case where we
+        know the .mat isn't the problem.
+        '''
+        matfile_path = os.path.join('test_data', 'hamming_7_5_6.mat')
+        output_path = os.path.join(self.temp_folder, 'hamming_out.txt')
+        assert os.path.exists(matfile_path), \
+            "There's nothing at the path " + matfile_path
+        result = slv.sdpt3_solve_mat(matfile_path,
+                                     'octave',
+                                     output_target=output_path,
+                                     discard_matfile=False,
+                                     cmd=OCTAVE_CMD)
+
+        self.assertAlmostEqual(result['primal_z'], -42.6666661, places=2)
+
+    def test_submission(self):
+        '''
+        Set up the data for two cases of b (0 or nonzero) and two cases of 'f' (2 or 6)
+        '''
+        A = 1.*np.array([[1, 0, 0, 0],  # X00 = 1
+                         [0, 0, 0, 1]]) # X11 = 1
+        b = 1.*np.array([1, 1]).reshape(2, 1)
+        c = 1.*np.array([0, 1, 0, 0]).reshape(1, 4)
+        K = {'l': 0., 's': [2.]}
+
+        matfile_target = os.path.join(self.temp_folder, 'matfile.mat')
+        output_target = os.path.join(self.temp_folder, 'output.txt')
+
+        sw.write_sedumi_to_mat(A, b, c, K, matfile_target)
+        result = slv.sdpt3_solve_mat(matfile_target,
+                                     'octave',
+                                     output_target=output_target,
+                                     cmd=OCTAVE_CMD)
+        res.print_summary(result)
+
+
+
+class TestBlackbox(unittest.TestCase):
+    '''
+    Test the overall process from start to finish
+    '''
+    @classmethod
+    def setUpClass(cls):
+        cls.X = cvxpy.Semidef(3)
+        cls.constraints = []
+
+        for i in range(3):
+            cls.constraints += [cls.X[i, i] == 1]
+
+        cls.constraints += [cls.X[0, 1] >= -0.2,
+                            cls.X[0, 1] <= -0.1,
+                            cls.X[1, 2] >= 0.4,
+                            cls.X[1, 2] <= 0.5]
+
+        cls.temp_folder = os.path.abspath("./temp")
+        if not os.path.exists(cls.temp_folder):
+            os.makedirs(cls.temp_folder)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.temp_folder)
+
+    def test_min(self):
+        '''
+        min y s.t.
+            -0.2 <= x <= -0.1
+            0.4 <= z <=  0.5
+            [1  x  y]
+            |x  1  z| is PSD
+            [y  z  1]
+        '''
+        matfile_target = os.path.join(self.temp_folder, 'matfilemin.mat')
+        output_target = os.path.join(self.temp_folder, 'outputmin.txt')
+
+        obj = cvxpy.Minimize(self.X[0, 2])
+        problem = cvxpy.Problem(obj, self.constraints)
+        result = slv.sdpt3_solve_problem(problem,
+                                         'octave',
+                                         matfile_target,
+                                         output_target=output_target,
+                                         cmd=OCTAVE_CMD)
+        self.assertAlmostEqual(result['primal_z'], -0.978, places=2)
+
+    @unittest.expectedFailure
+    def test_max(self):
+        '''
+        max y s.t.
+            -0.2 <= x <= -0.1
+            0.4 <= z <=  0.5
+            [1  x  y]
+            |x  1  z| is PSD
+            [y  z  1]
+        '''
+        matfile_target = os.path.join(self.temp_folder, 'matfilemax.mat')
+        output_target = os.path.join(self.temp_folder, 'outputmax.txt')
+
+        obj = cvxpy.Maximize(self.X[0, 2])
+        problem = cvxpy.Problem(obj, self.constraints)
+        result = slv.sdpt3_solve_problem(problem,
+                                         'octave',
+                                         matfile_target,
+                                         output_target=output_target,
+                                         cmd=OCTAVE_CMD)
+        # The opt value of the max problem is ~0.871921, but when we retrieved
+        # the cvxopt data it was flipped to be a min problem, so for now this
+        # is an expected failure until we figure out how to tell from the cvxpy
+        # problem whether it's min or max.
+        self.assertAlmostEqual(result['primal_z'], 0.872, places=2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I updated `solve_locally.octave_solve` to support newest Octave 4.0, which has [SDPT3](https://github.com/sqlp/sdpt3) package. I also added unit tests for such function and passed in my environment, Octave on docker ([jkawamoto/octave-sdpt3](https://hub.docker.com/r/jkawamoto/octave-sdpt3/)). However, I have tested only on such environment and it doesn't work on Travis. So, I disabled the unit tests for octave, currently. This PR partly solves issue #3.
