### PR TITLE
Refactoring package.

### DIFF
--- a/sdpt3glue/result.py
+++ b/sdpt3glue/result.py
@@ -16,22 +16,22 @@ from numpy import zeros
 
 
 _SDPT3_POS_STATUS_MAP_VERB = (
-    'max(relative gap,infeasibility) < gaptol (OPTIMAL)',
-    'primal problem is suspected to be infeasible',
-    'dual problem is suspected to be infeasible',
+    'max(relative gap,infeasibility) < gaptol (OPTIMAL)\n',
+    'primal problem is suspected to be infeasible\n',
+    'dual problem is suspected to be infeasible\n',
     'norm(X) or norm(Z) diverging'
 )
 
 _SDPT3_NEG_STATUS_MAP_VERB = (
-    'max(relative gap,infeasibility) < gaptol (OPTIMAL)',
-    'relative gap < infeasibility',
-    'lack of progress in predictor or corrector',
-    'X or Z not positive definite',
-    'difficulty in computing predictor or corrector direction',
-    'progress in relative gap or infeasibility is bad',
-    'maximum number of iterations reached',
-    'primal infeasibility has deteriorated too much',
-    'progress in relative gap has deteriorated',
+    'max(relative gap,infeasibility) < gaptol (OPTIMAL)\n',
+    'relative gap < infeasibility\n',
+    'lack of progress in predictor or corrector\n',
+    'X or Z not positive definite\n',
+    'difficulty in computing predictor or corrector direction\n',
+    'progress in relative gap or infeasibility is bad\n',
+    'maximum number of iterations reached\n',
+    'primal infeasibility has deteriorated too much\n',
+    'progress in relative gap has deteriorated\n',
     'lack of progress in infeasibility'
 )
 

--- a/sdpt3glue/result.py
+++ b/sdpt3glue/result.py
@@ -35,6 +35,22 @@ _SDPT3_NEG_STATUS_MAP_VERB = (
     'lack of progress in infeasibility'
 )
 
+_KEY_LIST = {
+    'number of iterations': 'iterations',
+    'primal objective value': 'primal_z',
+    'dual objective value': 'dual_z',
+    'gap': 'abs_gap',
+    'relative gap': 'rel_gap',
+    'actual relative gap': 'actual_rel_gap',
+    'rel. primal infeas': 'rel_primal_feas',
+    'rel. dual infeas': 'rel_dual_feas',
+    'Total CPU time (secs)': 'solve_time',
+    'CPU time per iteration': 'solve_time_per_iter',
+    'termination code': 'status_num'
+}
+"""the key is what we look for in the SDPT3 message output, the value is
+the name of key we'll save the information to in the output dict."""
+
 
 def make_result_dict(msg):
     '''
@@ -89,22 +105,7 @@ def extract_prop_dict(msg):
     constructs and returns a dictionary of basic solve result information.
     '''
     result_dict = {}
-
-    # the key is what we look for in the SDPT3 message output, the value is
-    # the name of key we'll save the information to in the output dict.
-    keylist = {'number of iterations': 'iterations',
-               'primal objective value': 'primal_z',
-               'dual objective value': 'dual_z',
-               'gap': 'abs_gap',
-               'relative gap': 'rel_gap',
-               'actual relative gap': 'actual_rel_gap',
-               'rel. primal infeas': 'rel_primal_feas',
-               'rel. dual infeas': 'rel_dual_feas',
-               'Total CPU time (secs)': 'solve_time',
-               'CPU time per iteration': 'solve_time_per_iter',
-               'termination code': 'status_num'}
-
-    for key in keylist.values():
+    for key in _KEY_LIST.values():
         result_dict[key] = None
 
     line_pattern = re.compile(
@@ -117,8 +118,8 @@ def extract_prop_dict(msg):
         key = line_parts[0].rstrip().replace("dual  ", "dual")
         val = handle_msg_item(line_parts[-1].strip())
 
-        if key in keylist and keylist[key] is not None:
-            result_dict[keylist[key]] = val
+        if key in _KEY_LIST and _KEY_LIST[key] is not None:
+            result_dict[_KEY_LIST[key]] = val
     return result_dict
 
 

--- a/sdpt3glue/solve_locally.py
+++ b/sdpt3glue/solve_locally.py
@@ -20,20 +20,6 @@ import subprocess
 import tempfile
 
 
-class MatlabCallError(Exception):
-    '''
-    This error is raised when an error occurs during a subprocess call to Matlab.
-    '''
-    pass
-
-
-class OctaveCallError(Exception):
-    '''
-    This error is raised when an error occurs during a subprocess call to Octave.
-    '''
-    pass
-
-
 class SubprocessCallError(Exception):
     '''
     This error is raised when an error occurs during a subprocess call.
@@ -51,14 +37,14 @@ def matlab_solve(matfile_target, discard_matfile=True):
 
     Returns:
         A dictionary with solve result information.
+
+    Raises:
+        SubprocessCallError when some error happens while executing matlab.
     '''
     # Generating the .mat file
     run_command = "matlab -r \"SDPT3solve('{0}')\" -nodisplay -nojvm".format(
         matfile_target)
-    try:
-        msg = run_command_get_output(run_command)
-    except SubprocessCallError, e:
-        raise MatlabCallError(e)
+    msg = _run_command_get_output(run_command)
 
     # Cleanup
     if discard_matfile:
@@ -79,6 +65,9 @@ def octave_solve(matfile_target, discard_matfile=True, cmd="octave"):
 
     Returns:
         A dictionary with solve result information.
+
+    Raises:
+        SubprocessCallError when some error happens while executing octave.
     '''
     # Generating the .mat file
     with tempfile.NamedTemporaryFile(
@@ -93,10 +82,7 @@ def octave_solve(matfile_target, discard_matfile=True, cmd="octave"):
 
         run_command = "{cmd} {script}".format(
             cmd=cmd, script=os.path.relpath(runner.name))
-        try:
-            msg = run_command_get_output(run_command)
-        except SubprocessCallError, e:
-            raise OctaveCallError(e)
+        msg = _run_command_get_output(run_command)
 
     # Cleanup
     if discard_matfile:
@@ -106,7 +92,7 @@ def octave_solve(matfile_target, discard_matfile=True, cmd="octave"):
     return msg
 
 
-def run_command_get_output(run_command):
+def _run_command_get_output(run_command):
     '''
     Runs the command run_command, saves the output to output_target, and
     returns the output log.

--- a/sdpt3glue/solve_neos.py
+++ b/sdpt3glue/solve_neos.py
@@ -38,9 +38,11 @@ def _print_fault(err, space=2):
       err: xmlrpclib.Fault error.
       space: Space size to be added before each message.
     """
-    print " " * space + "A fault occurred"
-    print " " * space + "Fault code: {0}".format(err.faultCode)
-    print " " * space + "Fault string: {0}".format(err.faultString)
+    print (
+        "{indent}A fault occurred\n"
+        "{indent}Fault code: {code}\n"
+        "{indent}Fault string: {msg}"
+    ).format(code=err.faultCode, msg=err.faultString, indent=" " * space)
 
 
 def _print_protocol_error(err, space=2):
@@ -50,11 +52,15 @@ def _print_protocol_error(err, space=2):
       err: xmlrpclib.ProtocolError error.
       space: Space size to be added before each message.
     """
-    print " " * space + "A protocol error occurred"
-    print " " * space + "URL: {0}".format(err.url)
-    print " " * space + "HTTP/HTTPS headers: {0}".format(err.headers)
-    print " " * space + "Error code: {0}".format(err.errcode)
-    print " " * space + "Error message: {0}".format(err.errmsg)
+    print (
+        "{indent}A protocol error occurred\n"
+        "{indent}URL: {url}\n"
+        "{indent}HTTP/HTTPS headers: {headers}\n"
+        "{indent}Error code: {code}\n"
+        "{indent}Error message: {msg}\n"
+    ).format(
+        url=err.url, msg=err.errmsg, headers=err.headers,
+        code=err.errcode, indent=" " * space)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This PR has some refactoring. At first, three exception classes are merged to one so that users don't need to catch each exception. For example, 

``` py
try:
    # executing matlab or octave depending on environment.
except MatlabCallError:
    # error handling for matlab case.
except OctaveCallError:
    # error handling for octave case.
```

can handle each case but I think there are less difference in both case. Thus,

``` py
try:
    # executing matlab or octave depending on environment.
except SubprocessCallError:
    # general error handling 
    if matlab:
        # for matlab case.
    else:
        # for octave case.
```

seems enough.

Next, keylist has been made each time calling make_result_dict. I moved it to a kind of constant.
However, there could be a discussion like global constant vs. local variables,
i.e. should we avoid global constants.

I also added new lines to messages I've forgotten.
