### PR TITLE
Hosting the document in GitHub pages.

### DIFF
--- a/misc/index.html
+++ b/misc/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="5; URL=https://discardthree.github.io/pysdpt3glue/">
+    <title>sdpt3glue documentation</title>
+  </head>
+  <body>
+    <p>
+      Document is moved to
+      <a href="https://discardthree.github.io/pysdpt3glue/">https://discardthree.github.io/pysdpt3glue/</a>
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
[GitHub pages](https://pages.github.com/) is a document hosting service by GitHub. Html files in `gh-pages` blanch are shown via https://discardthree.github.io/pysdpt3glue/. You can update document using [ghp-import](https://github.com/davisp/ghp-import). After compiling documents, run

``` sh
ghp-import docs/build/html 
```

on the root directory, then push `ghp-import` branch.

It is also helpful to redirect old document space hosted in some python server. `misc/index.html` has a redirect information. You can zip it and upload via PyPi.
