### PR TITLE
Change CVXPY version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 
 CVXcanon>=0.1.0           # via cvxpy
 cvxopt>=1.1.8
-cvxpy>=0.4.2
+cvxpy==0.4.2              # Change to >= 0.4.4 after it’s released. 0.4.3 causes a problem if we don’t have cvxopt.
 dill>=0.2.5               # via multiprocess
 ecos>=2.0.4               # via cvxpy
 fastcache>=1.0.2          # via cvxpy


### PR DESCRIPTION
As discussed in issue #33, fix ourselves to cvxpy 0.4.2 until 0.4.4 comes out.
