### PR TITLE
no_prompt option in sdpt3_solve_mat

### DIFF
--- a/sdpt3glue/solve.py
+++ b/sdpt3glue/solve.py
@@ -85,7 +85,7 @@ def sdpt3_solve_mat(
     elif mode == NEOS:
         import solve_neos as ns
         msg = ns.neos_solve(matfile_path,
-                            discard_matfile=discard_matfile)
+                            discard_matfile=discard_matfile, **kwargs)
 
     if output_target:
         with open(output_target, "w") as fp:

--- a/sdpt3glue/solve_locally.py
+++ b/sdpt3glue/solve_locally.py
@@ -27,7 +27,7 @@ class SubprocessCallError(Exception):
     pass
 
 
-def matlab_solve(matfile_target, discard_matfile=True):
+def matlab_solve(matfile_target, discard_matfile=True, **_):
     '''
     The .mat is loaded into matlab and the problem is solved with SDPT3.
 
@@ -54,7 +54,7 @@ def matlab_solve(matfile_target, discard_matfile=True):
     return msg
 
 
-def octave_solve(matfile_target, discard_matfile=True, cmd="octave"):
+def octave_solve(matfile_target, discard_matfile=True, cmd="octave", **_):
     '''
     The .mat is loaded into octave and the problem is solved with SDPT3.
 

--- a/sdpt3glue/solve_neos.py
+++ b/sdpt3glue/solve_neos.py
@@ -102,7 +102,7 @@ class NeosError(Exception):
 
 def neos_solve(
         matfile_target, discard_matfile=True, no_prompt=False,
-        return_id_pwd=False):
+        return_id_pwd=False, **_):
     '''
     Submits the Sedumi format .mat file to be solved on NEOS with SDPT3.
     Returns the solve result message from NEOS.

--- a/tests/unittest_neos.py
+++ b/tests/unittest_neos.py
@@ -56,7 +56,7 @@ class TestSimpleNEOSSolve(unittest.TestCase):
             "There's nothing at the path " + matfile_path)
         result = sdpt3glue.sdpt3_solve_mat(
             matfile_path, sdpt3glue.NEOS,
-            output_target=output_path, discard_matfile=False)
+            output_target=output_path, discard_matfile=False, no_prompt=True)
 
         self.assertAlmostEqual(result['primal_z'], -42.6666661, places=2)
 
@@ -75,7 +75,8 @@ class TestSimpleNEOSSolve(unittest.TestCase):
 
         sdpt3glue.write_sedumi_to_mat(A, b, c, K, matfile_target)
         result = sdpt3glue.sdpt3_solve_mat(
-            matfile_target, sdpt3glue.NEOS, output_target=output_target)
+            matfile_target, sdpt3glue.NEOS,
+            output_target=output_target, no_prompt=True)
         sdpt3glue.print_summary(result)
 
 


### PR DESCRIPTION
This PR modifies sdpt3_solve_mat so that it takes no_prompt option. Previously only neos_solve has this option and it is hard to pass the preference to sdpt3_solve_mat. With this update, you can pass it like

```py
sdpt3glue.sdpt3_solve_mat(
    matfile_path, sdpt3glue.NEOS,
    output_target=output_path, discard_matfile=False, no_prompt=True)
```

